### PR TITLE
Fix drawio-integration includes

### DIFF
--- a/ajax/copystylestodb.php
+++ b/ajax/copystylestodb.php
@@ -43,7 +43,7 @@ if ($result=$DB->query($query)) {
 	}
 	if (isset($datas['value']))
 	{
-		$filename = Plugin::getPhpDir("archimap")."/drawio-integration/styles/" . $datas['value'];
+		$filename = Plugin::getPhpDir("archimap")."/public/drawio-integration/styles/" . $datas['value'];
 		$styles = file_get_contents($filename);
 		if ($styles)
 		{

--- a/inc/diagram.class.php
+++ b/inc/diagram.class.php
@@ -105,7 +105,7 @@ class PluginArchimapDiagram extends CommonDBChild {
 		}
 //		get list of file names in drawio-integration/libraries to upload custom libraries
 		$customlibs = [];
-		$customlibslist = glob(Plugin::getPhpDir("archimap").'/drawio-integration/libraries/*.xml');
+		$customlibslist = glob(Plugin::getPhpDir("archimap").'/public/drawio-integration/libraries/*.xml');
 		if ($customlibslist) {
 			foreach ($customlibslist as $filename) 
 			{	$p = pathinfo($filename);

--- a/public/drawio-integration/ajax/postconfig.php
+++ b/public/drawio-integration/ajax/postconfig.php
@@ -50,6 +50,6 @@ foreach($keys as $key => $typevalue) {
 echo json_encode($result);
 if ($nbstyles)
 {
-	include (Plugin::getPhpDir("archimap")."/drawio-integration/ajax/copystylestofile.php"); // copy STYLE entries into file
+	include (Plugin::getPhpDir("archimap")."/public/drawio-integration/ajax/copystylestofile.php"); // copy STYLE entries into file
 }
 ?>

--- a/public/drawio-integration/ajax/putconfig.php
+++ b/public/drawio-integration/ajax/putconfig.php
@@ -51,6 +51,6 @@ echo json_encode($datas);
 // if one key = STYLE, write all styles into a file
 if ($nbstyles)
 {
-	include (Plugin::getPhpDir("archimap")."/drawio-integration/ajax/copystylestofile.php"); // copy STYLE entries into file
+	include (Plugin::getPhpDir("archimap")."/public/drawio-integration/ajax/copystylestofile.php"); // copy STYLE entries into file
 }
 ?>


### PR DESCRIPTION
In the recent versions the `drawio-integration` folder has been moved to the `public` one but some references in the code are not pointing correctly to it.

This PR fixes all the paths.