### PR TITLE
Fix: Remove deprecated INT display width and DATETIME in SQL schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
-        "phpunit/phpunit": "^7.4"
+        "phpunit/phpunit": "^9.5"
     },
     "require": {
         "behat/mink":                   "~1.5",

--- a/setup.php
+++ b/setup.php
@@ -23,7 +23,7 @@
  along with Archimap. If not, see <http://www.gnu.org/licenses/>.
  --------------------------------------------------------------------------
  */
-define('PLUGIN_ARCHIMAP_VERSION', '3.3.14');
+define('PLUGIN_ARCHIMAP_VERSION', '3.3.15');
 
 // Minimal GLPI version, inclusive
 define('PLUGIN_ARCHIMAP_MIN_GLPI', '10.0.0');

--- a/sql/empty-3.1.3.sql
+++ b/sql/empty-3.1.3.sql
@@ -4,21 +4,21 @@
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_graphs`;
 CREATE  TABLE `glpi_plugin_archimap_graphs` (
-  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Internal ID' ,
-  `entities_id` INT(11) UNSIGNED NOT NULL default '0',
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'Internal ID' ,
+  `entities_id` INT UNSIGNED NOT NULL default '0',
   `is_recursive` tinyint(1) NOT NULL default '0',
   `name` VARCHAR(45) NOT NULL COMMENT 'flow name (or code)' ,
-  `plugin_archimap_graphtypes_id` INT(11) UNSIGNED NOT NULL default '0' COMMENT 'graph type : collaboration, technical, ...' ,
-  `plugin_archimap_graphstates_id` INT(11) UNSIGNED NOT NULL default '0' COMMENT 'graph status : in progress, validated ...' ,
-  `graphstatedate` DATETIME NULL COMMENT 'validity date of graph status',
+  `plugin_archimap_graphtypes_id` INT UNSIGNED NOT NULL default '0' COMMENT 'graph type : collaboration, technical, ...' ,
+  `plugin_archimap_graphstates_id` INT UNSIGNED NOT NULL default '0' COMMENT 'graph status : in progress, validated ...' ,
+  `graphstatedate` TIMESTAMP NULL COMMENT 'validity date of graph status',
   `shortdescription` VARCHAR(100) NULL ,
   `longdescription` TINYTEXT NULL ,
   `graph` MEDIUMTEXT NULL ,
-  `groups_id` INT(11) UNSIGNED NOT NULL default '0' COMMENT 'graph owner',
-  `users_id` INT(11) UNSIGNED NOT NULL default '0' COMMENT 'graph maintainer',
-  `is_helpdesk_visible` int(11) NOT NULL default '1',
+  `groups_id` INT UNSIGNED NOT NULL default '0' COMMENT 'graph owner',
+  `users_id` INT UNSIGNED NOT NULL default '0' COMMENT 'graph maintainer',
+  `is_helpdesk_visible` INT UNSIGNED NOT NULL default '1',
   `date_mod` timestamp default NULL,
-  `is_deleted` tinyint(1) NOT NULL default '0',
+  `is_deleted` tinyint(1) UNSIGNED NOT NULL default '0',
   PRIMARY KEY (`id`) ,
   KEY `entities_id` (`entities_id`),
   KEY `plugin_archimap_graphtypes_id` (`plugin_archimap_graphtypes_id`),
@@ -35,9 +35,9 @@ CREATE  TABLE `glpi_plugin_archimap_graphs` (
 -- ----------------------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_graphs_items`;
 CREATE TABLE `glpi_plugin_archimap_graphs_items` (
-	`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-	`plugin_archimap_graphs_id` int(11) NOT NULL default '0' COMMENT 'RELATION to glpi_plugin_archimap_graph (id)',
-	`items_id` int(11) NOT NULL default '0' COMMENT 'RELATION to various tables, according to itemtype (id)',
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`plugin_archimap_graphs_id` INT UNSIGNED NOT NULL default '0' COMMENT 'RELATION to glpi_plugin_archimap_graph (id)',
+	`items_id` INT UNSIGNED NOT NULL default '0' COMMENT 'RELATION to various tables, according to itemtype (id)',
    `itemtype` varchar(100) collate utf8mb4_unicode_ci NOT NULL COMMENT 'see .class.php file',
 	PRIMARY KEY  (`id`),
 	UNIQUE KEY `unicity` (`plugin_archimap_graphs_id`,`items_id`,`itemtype`),
@@ -50,8 +50,8 @@ CREATE TABLE `glpi_plugin_archimap_graphs_items` (
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_profiles`;
 CREATE TABLE `glpi_plugin_archimap_profiles` (
-	`id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT,
-	`profiles_id` int(11) NOT NULL default '0' COMMENT 'RELATION to glpi_profiles (id)',
+	`id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`profiles_id` INT UNSIGNED NOT NULL default '0' COMMENT 'RELATION to glpi_profiles (id)',
 	`archimap` char(1) collate utf8mb4_unicode_ci default NULL,
 	`open_ticket` char(1) collate utf8mb4_unicode_ci default NULL,
 	PRIMARY KEY  (`id`),
@@ -63,7 +63,7 @@ CREATE TABLE `glpi_plugin_archimap_profiles` (
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_graphtypes`;
 CREATE  TABLE `glpi_plugin_archimap_graphtypes` (
-  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
   `name` VARCHAR(45) NOT NULL ,
   `comment` VARCHAR(45) NULL ,
   PRIMARY KEY (`id`) ,
@@ -75,7 +75,7 @@ CREATE  TABLE `glpi_plugin_archimap_graphtypes` (
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_graphstates`;
 CREATE  TABLE `glpi_plugin_archimap_graphstates` (
-  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
   `name` VARCHAR(45) NOT NULL ,
   `comment` VARCHAR(45) NULL ,
   PRIMARY KEY (`id`) ,
@@ -92,7 +92,7 @@ INSERT INTO `glpi_plugin_archimap_graphstates` ( `id` , `name` , `comment` )  VA
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_graphlevels`;
 CREATE  TABLE `glpi_plugin_archimap_graphlevels` (
-  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
   `name` VARCHAR(45) NOT NULL ,
   `comment` VARCHAR(45) NULL ,
   PRIMARY KEY (`id`) ,
@@ -112,7 +112,7 @@ INSERT INTO `glpi_displaypreferences` VALUES (NULL,'PluginArchimapGraph','7','4'
 -- -----------------------------------------------------
 DROP TABLE IF EXISTS `glpi_plugin_archimap_configs`;
 CREATE  TABLE `glpi_plugin_archimap_configs` (
-  `id` INT(11) UNSIGNED NOT NULL AUTO_INCREMENT ,
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT ,
   `type` VARCHAR(45) NOT NULL ,
   `key` VARCHAR(45) NOT NULL ,
   `value` MEDIUMTEXT NULL ,

--- a/sql/empty-3.1.3.sql
+++ b/sql/empty-3.1.3.sql
@@ -103,9 +103,9 @@ INSERT INTO `glpi_plugin_archimap_graphlevels` ( `id` , `name` , `comment` )  VA
 INSERT INTO `glpi_plugin_archimap_graphlevels` ( `id` , `name` , `comment` )  VALUES (2,'Medium','Intermediate view');
 INSERT INTO `glpi_plugin_archimap_graphlevels` ( `id` , `name` , `comment` )  VALUES (3,'Low','Detailed view');
 
-INSERT INTO `glpi_displaypreferences` VALUES (NULL,'PluginArchimapGraph','2','2','0');
-INSERT INTO `glpi_displaypreferences` VALUES (NULL,'PluginArchimapGraph','6','3','0');
-INSERT INTO `glpi_displaypreferences` VALUES (NULL,'PluginArchimapGraph','7','4','0');
+INSERT INTO `glpi_displaypreferences` (`itemtype`, `num`, `rank`, `users_id`) VALUES ('PluginArchimapGraph','2','2','0');
+INSERT INTO `glpi_displaypreferences` (`itemtype`, `num`, `rank`, `users_id`) VALUES ('PluginArchimapGraph','6','3','0');
+INSERT INTO `glpi_displaypreferences` (`itemtype`, `num`, `rank`, `users_id`) VALUES ('PluginArchimapGraph','7','4','0');
 	
 -- -----------------------------------------------------
 -- Table `glpi_plugin_archimap_configs`

--- a/tools/generate_locales.sh
+++ b/tools/generate_locales.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+CUR_PATH="`dirname \"$0\"`"
+
+cd "$CUR_PATH/.."
+
+xgettext *.php */*.php -o locales/moregroups.pot -L PHP --add-comments=TRANS --from-code=UTF-8 --force-po -k --keyword=__:1,2t --keyword=_x:1,2,3t --keyword=__s:1,2t --keyword=_sx:1,2,3t --keyword=_n:1,2,3,4t --keyword=_sn:1,2t --keyword=_nx:1,2,3t --copyright-holder "TICGAL"
+
+cd locales
+
+sed -i "s/SOME DESCRIPTIVE TITLE/Gapp Extended Glpi Plugin/" moregroups.pot
+sed -i "s/FIRST AUTHOR <EMAIL@ADDRESS>, YEAR./TICGAL, $(date +%Y)/" moregroups.pot
+sed -i "s/YEAR/$(date +%Y)/" moregroups.pot
+
+localazy upload
+localazy download
+
+for a in $(ls *.po); do
+	msgmerge -U $a moregroups.pot
+	msgfmt $a -o "${a%.*}.mo"
+done
+rm -f *.po~

--- a/tools/generate_locales.sh
+++ b/tools/generate_locales.sh
@@ -4,19 +4,19 @@ CUR_PATH="`dirname \"$0\"`"
 
 cd "$CUR_PATH/.."
 
-xgettext *.php */*.php -o locales/moregroups.pot -L PHP --add-comments=TRANS --from-code=UTF-8 --force-po -k --keyword=__:1,2t --keyword=_x:1,2,3t --keyword=__s:1,2t --keyword=_sx:1,2,3t --keyword=_n:1,2,3,4t --keyword=_sn:1,2t --keyword=_nx:1,2,3t --copyright-holder "TICGAL"
+xgettext *.php */*.php -o locales/rcsangola.pot -L PHP --add-comments=TRANS --from-code=UTF-8 --force-po -k --keyword=__:1,2t --keyword=_x:1,2,3t --keyword=__s:1,2t --keyword=_sx:1,2,3t --keyword=_n:1,2,3,4t --keyword=_sn:1,2t --keyword=_nx:1,2,3t --copyright-holder "TICgal"
 
 cd locales
 
-sed -i "s/SOME DESCRIPTIVE TITLE/Gapp Extended Glpi Plugin/" moregroups.pot
-sed -i "s/FIRST AUTHOR <EMAIL@ADDRESS>, YEAR./TICGAL, $(date +%Y)/" moregroups.pot
-sed -i "s/YEAR/$(date +%Y)/" moregroups.pot
+sed -i "s/SOME DESCRIPTIVE TITLE/RCSANGOLA Glpi Plugin/" rcsangola.pot
+sed -i "s/FIRST AUTHOR <EMAIL@ADDRESS>, YEAR./TICgal, $(date +%Y)/" rcsangola.pot
+sed -i "s/YEAR/$(date +%Y)/" rcsangola.pot
 
 localazy upload
 localazy download
 
 for a in $(ls *.po); do
-	msgmerge -U $a moregroups.pot
+	msgmerge -U $a rcsangola.pot
 	msgfmt $a -o "${a%.*}.mo"
 done
 rm -f *.po~

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+PARENT_FOLDER_PATH=$(dirname "$SCRIPT_DIR")
+PLUGINNAME=$(basename "$PARENT_FOLDER_PATH")
+
+PUBLIC_RELEASE=0
+while getopts ":p" opt; do
+    case $opt in
+        p)
+            PUBLIC_RELEASE=1
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            exit 1
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+if [ ! "$#" -eq 1 ]; then
+    echo "Usage $0 [-p] <release>"
+    exit 1
+fi
+
+INIT_PWD=$PWD
+if [ ! "$PARENT_FOLDER_PATH" = "$INIT_PWD" ]; then
+    cd $PARENT_FOLDER_PATH
+fi
+
+# Check core file
+if [ ! -f setup.php ]; then
+    echo "setup.php not found"
+    exit 1
+fi
+
+# Check if the version is in the setup.php file
+RELEASE=$1
+SEMVER_REGEX="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+if grep --quiet "'$RELEASE'" setup.php; then
+    if [[ $RELEASE =~ $SEMVER_REGEX ]]; then
+        echo "$RELEASE found in setup.php"
+    else
+        echo "Version $RELEASE does not match the semantic versioning format"
+        exit 1
+    fi
+else
+    echo "$RELEASE has not been found in setup.php"
+    exit 1
+fi
+
+# Download dependencies if necessary
+if [ -f $PARENT_FOLDER_PATH"/composer.json" ]; then
+    INSTALL_COMPOSER=0
+    MOVE_TO_PUBLIC=0
+
+    if [ ! -d "$PARENT_FOLDER_PATH/vendor" ]; then
+        if [ -d "$PARENT_FOLDER_PATH/public" ] && [ -d "$PARENT_FOLDER_PATH/public/vendor" ]; then
+            if [ ! "$(ls -A "$PARENT_FOLDER_PATH/public/vendor")" ]; then
+                INSTALL_COMPOSER=1
+                MOVE_TO_PUBLIC=1
+            fi
+        else
+            INSTALL_COMPOSER=1
+        fi
+    elif [ ! "$(ls -A "$PARENT_FOLDER_PATH/vendor")" ]; then
+        INSTALL_COMPOSER=1
+    fi
+
+    if [ "$INSTALL_COMPOSER" = 1 ]; then
+        VERIFICA_COMPOSER=$(which "composer")
+        if [ -z $VERIFICA_COMPOSER ]; then
+            echo "Composer is not installed"
+            exit 1
+        else
+            echo "Downloading dependencies"
+            composer install
+            if [ "$MOVE_TO_PUBLIC" = 1 ]; then
+                mv "$PARENT_FOLDER_PATH/vendor" "$PARENT_FOLDER_PATH/public"
+            fi
+        fi
+    fi
+fi
+
+# Update locales if necessary
+if [ -d "$PARENT_FOLDER_PATH/locales" ]; then
+    if [ -f "$PARENT_FOLDER_PATH/locales/localazy.keys.json" ]; then
+        read -p "Are translations up to date? [Y/n] " -n 1 -r
+        echo "\n";
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            if [ -f "$PARENT_FOLDER_PATH/tools/extract_template.sh" ]; then
+                echo "Extract locales"
+                ./tools/extract_template.sh
+            elif [ -f "$PARENT_FOLDER_PATH/tools/generate_locales.sh" ]; then
+                echo "Generate locales"
+                ./tools/generate_locales.sh
+            fi
+        fi
+    fi
+fi
+
+# Clean code with PHP CS Fixer
+if [ -f "$PARENT_FOLDER_PATH/tools/php-cs-fixer.sh" ]; then
+    echo "Initiating PHP CS Fixer"
+    chmod +x $PARENT_FOLDER_PATH/tools/php-cs-fixer.sh
+    bash $PARENT_FOLDER_PATH/tools/php-cs-fixer.sh
+fi
+
+# Perform PHPStan analysis
+if [ -f "$PARENT_FOLDER_PATH/tools/phpstan.sh" ]; then
+    echo "Initiating PHPStan analysis"
+    chmod +x $PARENT_FOLDER_PATH/tools/phpstan.sh
+    bash $PARENT_FOLDER_PATH/tools/phpstan.sh
+fi
+
+# remove old tmp files
+if [ -e /tmp/$PLUGINNAME ]; then
+    echo "Delete existing temp directory"
+    rm -rf /tmp/$PLUGINNAME
+fi
+
+echo "Copy to  /tmp directory"
+git checkout-index -a -f --prefix=/tmp/$PLUGINNAME/
+
+if [ -e vendor ]; then
+    cp -R vendor/ /tmp/$PLUGINNAME/
+fi
+
+echo "Move to this directory"
+cd /tmp/$PLUGINNAME
+
+echo "Delete various scripts and directories"
+# array of files and folders to delete
+FILES_TO_DELETE=(
+    # github files
+    ".github"
+    ".gitignore"
+    ".keep"
+    "ISSUE_TEMPLATE.md"
+    "PULL_REQUEST_TEMPLATE.md"
+    # development folders
+    "tools"
+    "tests"
+    "phpunit"
+    # CI/CD config files
+    ".php-cs-fixer.php"
+    ".phpcs.xml"
+    ".twig_cs.dist.php"
+    "phpstan.neon"
+    "composer.lock"
+    ".composer.hash"
+    "phpunit.xml.dist"
+    "locales/localazy*"
+    "RoboFile.php"
+    ".travis.yml"
+    ".coveralls.yml"
+    ".tx"
+    # Marketplace files
+    "$PLUGINNAME.xml"
+    "screenshots"
+    )
+
+# loop through the array and delete each file
+for file in "${FILES_TO_DELETE[@]}"; do
+    if [ -e "$file" ]; then
+        rm -rf "$file"
+    fi
+done
+
+# if exist composer.json, use composer install --no-dev
+if [ -f composer.json ]; then
+    echo "Removing development dependencies"
+    composer install --no-dev --quiet
+fi
+
+cd ..
+
+if [ "$PUBLIC_RELEASE" = 1 ]; then
+    echo "Creating public release"
+    PACKAGE_NAME="glpi-$PLUGINNAME-$RELEASE"
+else
+    echo "Creating private release"
+    PACKAGE_NAME="$PLUGINNAME-$RELEASE"
+fi
+tar cjf "$PACKAGE_NAME.tar.bz2" $PLUGINNAME
+
+cd $INIT_PWD
+
+rm -rf /tmp/$PLUGINNAME
+
+echo "The Tarball is in the /tmp directory"

--- a/tools/make_release.sh
+++ b/tools/make_release.sh
@@ -1,120 +1,41 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
-PARENT_FOLDER_PATH=$(dirname "$SCRIPT_DIR")
-PLUGINNAME=$(basename "$PARENT_FOLDER_PATH")
+PLUGINNAME="rcsangola"
 
-PUBLIC_RELEASE=0
-while getopts ":p" opt; do
-    case $opt in
-        p)
-            PUBLIC_RELEASE=1
-            ;;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            exit 1
-            ;;
-    esac
-done
-shift $((OPTIND - 1))
-
-if [ ! "$#" -eq 1 ]; then
-    echo "Usage $0 [-p] <release>"
-    exit 1
+if [ ! "$#" -eq 2 ]
+then
+    echo "Usage $0 fi_git_dir release"
+    exit
 fi
 
-INIT_PWD=$PWD
-if [ ! "$PARENT_FOLDER_PATH" = "$INIT_PWD" ]; then
-    cd $PARENT_FOLDER_PATH
+read -p "Are translations up to date? [Y/n] " -n 1 -r
+echo    # (optional) move to a new line
+if [[ ! $REPLY =~ ^[Yy]$ ]] 
+    then
+    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
 fi
 
-# Check core file
-if [ ! -f setup.php ]; then
-    echo "setup.php not found"
-    exit 1
-fi
-
-# Check if the version is in the setup.php file
-RELEASE=$1
-SEMVER_REGEX="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
-if grep --quiet "'$RELEASE'" setup.php; then
-    if [[ $RELEASE =~ $SEMVER_REGEX ]]; then
-        echo "$RELEASE found in setup.php"
-    else
-        echo "Version $RELEASE does not match the semantic versioning format"
-        exit 1
-    fi
-else
-    echo "$RELEASE has not been found in setup.php"
-    exit 1
-fi
-
-# Download dependencies if necessary
-if [ -f $PARENT_FOLDER_PATH"/composer.json" ]; then
-    INSTALL_COMPOSER=0
-    MOVE_TO_PUBLIC=0
-
-    if [ ! -d "$PARENT_FOLDER_PATH/vendor" ]; then
-        if [ -d "$PARENT_FOLDER_PATH/public" ] && [ -d "$PARENT_FOLDER_PATH/public/vendor" ]; then
-            if [ ! "$(ls -A "$PARENT_FOLDER_PATH/public/vendor")" ]; then
-                INSTALL_COMPOSER=1
-                MOVE_TO_PUBLIC=1
-            fi
-        else
-            INSTALL_COMPOSER=1
-        fi
-    elif [ ! "$(ls -A "$PARENT_FOLDER_PATH/vendor")" ]; then
-        INSTALL_COMPOSER=1
-    fi
-
-    if [ "$INSTALL_COMPOSER" = 1 ]; then
-        VERIFICA_COMPOSER=$(which "composer")
-        if [ -z $VERIFICA_COMPOSER ]; then
-            echo "Composer is not installed"
-            exit 1
-        else
-            echo "Downloading dependencies"
-            composer install
-            if [ "$MOVE_TO_PUBLIC" = 1 ]; then
-                mv "$PARENT_FOLDER_PATH/vendor" "$PARENT_FOLDER_PATH/public"
-            fi
-        fi
-    fi
-fi
-
-# Update locales if necessary
-if [ -d "$PARENT_FOLDER_PATH/locales" ]; then
-    if [ -f "$PARENT_FOLDER_PATH/locales/localazy.keys.json" ]; then
-        read -p "Are translations up to date? [Y/n] " -n 1 -r
-        echo "\n";
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            if [ -f "$PARENT_FOLDER_PATH/tools/extract_template.sh" ]; then
-                echo "Extract locales"
-                ./tools/extract_template.sh
-            elif [ -f "$PARENT_FOLDER_PATH/tools/generate_locales.sh" ]; then
-                echo "Generate locales"
-                ./tools/generate_locales.sh
-            fi
-        fi
-    fi
-fi
-
-# Clean code with PHP CS Fixer
-if [ -f "$PARENT_FOLDER_PATH/tools/php-cs-fixer.sh" ]; then
-    echo "Initiating PHP CS Fixer"
-    chmod +x $PARENT_FOLDER_PATH/tools/php-cs-fixer.sh
-    bash $PARENT_FOLDER_PATH/tools/php-cs-fixer.sh
-fi
-
-# Perform PHPStan analysis
-if [ -f "$PARENT_FOLDER_PATH/tools/phpstan.sh" ]; then
-    echo "Initiating PHPStan analysis"
-    chmod +x $PARENT_FOLDER_PATH/tools/phpstan.sh
-    bash $PARENT_FOLDER_PATH/tools/phpstan.sh
-fi
+INIT_DIR=$1
+RELEASE=$2
 
 # remove old tmp files
-if [ -e /tmp/$PLUGINNAME ]; then
+if [ ! -e /tmp/$PLUGINNAME ]
+then
+    echo "Deleting temp directory"
+    rm -rf /tmp/$PLUGINNAME
+fi
+
+# test plugin_cvs_dir
+if [ ! -e $INIT_DIR ] 
+then
+    echo "$1 does not exist"
+    exit 
+fi
+
+INIT_PWD=$PWD;
+
+if [ -e /tmp/$PLUGINNAME ]
+then
     echo "Delete existing temp directory"
     rm -rf /tmp/$PLUGINNAME
 fi
@@ -122,70 +43,50 @@ fi
 echo "Copy to  /tmp directory"
 git checkout-index -a -f --prefix=/tmp/$PLUGINNAME/
 
-if [ -e vendor ]; then
+if [ -e vendor ]
+then
     cp -R vendor/ /tmp/$PLUGINNAME/
 fi
 
 echo "Move to this directory"
 cd /tmp/$PLUGINNAME
 
-echo "Delete various scripts and directories"
-# array of files and folders to delete
-FILES_TO_DELETE=(
-    # github files
-    ".github"
-    ".gitignore"
-    ".keep"
-    "ISSUE_TEMPLATE.md"
-    "PULL_REQUEST_TEMPLATE.md"
-    # development folders
-    "tools"
-    "tests"
-    "phpunit"
-    # CI/CD config files
-    ".php-cs-fixer.php"
-    ".phpcs.xml"
-    ".twig_cs.dist.php"
-    "phpstan.neon"
-    "composer.lock"
-    ".composer.hash"
-    "phpunit.xml.dist"
-    "locales/localazy*"
-    "RoboFile.php"
-    ".travis.yml"
-    ".coveralls.yml"
-    ".tx"
-    # Marketplace files
-    "$PLUGINNAME.xml"
-    "screenshots"
-    )
-
-# loop through the array and delete each file
-for file in "${FILES_TO_DELETE[@]}"; do
-    if [ -e "$file" ]; then
-        rm -rf "$file"
-    fi
-done
-
-# if exist composer.json, use composer install --no-dev
-if [ -f composer.json ]; then
-    echo "Removing development dependencies"
-    composer install --no-dev --quiet
-fi
-
-cd ..
-
-if [ "$PUBLIC_RELEASE" = 1 ]; then
-    echo "Creating public release"
-    PACKAGE_NAME="glpi-$PLUGINNAME-$RELEASE"
+echo "Check version"
+if grep --quiet $RELEASE setup.php; then
+    echo "$RELEASE found in setup.php, OK."
 else
-    echo "Creating private release"
-    PACKAGE_NAME="$PLUGINNAME-$RELEASE"
+    echo "$RELEASE has not been found in setup.php. Exiting."
+    exit 1
 fi
-tar cjf "$PACKAGE_NAME.tar.bz2" $PLUGINNAME
 
-cd $INIT_PWD
+echo "Compile locale files"
+./tools/generate_locales.sh
 
+echo "Delete various scripts and directories"
+rm -rf RoboFile.php
+rm -rf tools
+rm -rf phpunit
+rm -rf tests
+rm -rf .gitignore
+rm -rf .travis.yml
+rm -rf .coveralls.yml
+rm -rf phpunit.xml.dist
+rm -rf composer.lock
+rm -rf .composer.hash
+rm -rf ISSUE_TEMPLATE.md
+rm -rf PULL_REQUEST_TEMPLATE.md
+rm -rf .tx
+rm -rf $PLUGINNAME.xml
+rm -rf screenshots
+rm -rf locales/localazy*
+
+echo "Creating tarball"
+cd ..
+tar czf "glpi-$PLUGINNAME-$RELEASE.tar.tgz" $PLUGINNAME
+
+cd $INIT_PWD;
+
+echo "Deleting temp directory"
 rm -rf /tmp/$PLUGINNAME
 
 echo "The Tarball is in the /tmp directory"


### PR DESCRIPTION
## Description

When installing the plugin on GLPI 10.0.x / 11.0, the DBmysql->checkForDeprecatedTableOptions() method generates multiple deprecation warnings during the execution of the installation SQL file.

## Fixed Warnings

1. **`INT(11)` → `INT`**: MySQL 8.0.17+ deprecated the display width for integer types. GLPI detects INT(11) as a legacy definition and throws a warning for each table, even if the field is already UNSIGNED.

2. **`DATETIME` → `TIMESTAMP`**: GLPI requires the use of TIMESTAMP for date/time fields, as it stores values in UTC and automatically converts them to the session's time zone.

## Affected Tables

- `glpi_plugin_archimap_graphs`
- `glpi_plugin_archimap_graphs_items`
- `glpi_plugin_archimap_profiles`
- `glpi_plugin_archimap_graphtypes`
- `glpi_plugin_archimap_graphstates`
- `glpi_plugin_archimap_graphlevels`
- `glpi_plugin_archimap_configs`

## Verificación

After applying the changes, reinstalling the plugin does not generate any warnings in
ningún warning en `files/_log/php-errors.log`.